### PR TITLE
Fix size preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 RSFormView is a library that helps you build fully customizable forms for data entry in a few minutes. 
 
-![](formExample.gif)
+<img src="https://github.com/rootstrap/RSFormView/blob/master/formExample.gif" height="440">
 
 ## Installation
 


### PR DESCRIPTION
The preview does not completely fit on the screen. I set the maximum height to `440`. I attach screenshots of how it looks:

<img width="400" alt="Screenshot 2019-05-18 at 15 40 34" src="https://user-images.githubusercontent.com/10995774/57969926-76a96380-7983-11e9-9fbc-f81d6ecb891c.png">
<img width="400" alt="Screenshot 2019-05-18 at 15 40 28" src="https://user-images.githubusercontent.com/10995774/57969927-76a96380-7983-11e9-841f-86669af6a282.png">
