### PR TITLE
New field type and validation for Double.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ formViewModel.fields().forEach {
 Cases: 
  - email: Will present the email keyboard when the field is selected and validate that the text entry is in an email format
  - date: Will present a native date picker when the field is selected and validate that the entry is not empty
- - numeric: Will present the numeric keyboard when the field is selected and validate that the text entry can be casted to Int
+ - integer: Will present the numeric keyboard when the field is selected and validate that the text entry can be casted to Int
+ - double: Will present the decimal keyboard when the field is selected and validate that the text entry can be casted to Double, max 2 decimal places
  - password: Will mask the text entry in UI and validate that the text entry is not empty
  - usPhone: Will decorate the text entry with slashes (111-111-1111) and validate that the text entry is in a valid US phone number format  
  
@@ -146,7 +147,8 @@ Cases:
  Cases: 
  - nonEmpty: Will mark the field invalid if the text entry is empty
  - none: No validation will be made, the field will never be marked invalid unless manually made so
- - numeric: Will mark the field invalid if the text entry is not a number
+ - integer: Will mark the field invalid if the text entry is not an integer
+ - double: Will mark the field invalid if the text entry is not a double, max 2 decimal places
  - usState: Will validate that the text entry matches the name or abbreviation of any of the US states
  - custom: Pass this case a block with your custom validation.
 

--- a/RSFormView/Classes/Extensions/StringExtension.swift
+++ b/RSFormView/Classes/Extensions/StringExtension.swift
@@ -14,8 +14,10 @@ extension String {
     switch type {
     case .email:
       isValid = isEmailFormatted()
-    case .numeric:
+    case .integer:
       isValid = isInteger()
+    case .double:
+        isValid = isValidDouble(maxDecimalPlaces: 2)
     case .usState:
       isValid = AddressManager.validateState(state: self)
     case .usPhone:
@@ -42,6 +44,32 @@ extension String {
   
   func isInteger() -> Bool {
     return Int(self) != nil
+  }
+    
+  // Credit to Markus Bodner for the tutorial this code is sourced from
+  // https://www.markusbodner.com/2017/06/20/how-to-verify-and-limit-decimal-number-inputs-in-ios-with-swift/
+  func isValidDouble(maxDecimalPlaces: Int) -> Bool {
+    // Use NumberFormatter to check if we can turn the string into a number
+    // and to get the locale specific decimal separator.
+    let formatter = NumberFormatter()
+    formatter.allowsFloats = true // Default is true, be explicit anyways
+    let decimalSeparator = formatter.decimalSeparator ?? "."  // Gets the locale specific decimal separator. If for some reason there is none we assume "." is used as separator.
+    // Check if we can create a valid number. (The formatter creates a NSNumber, but
+    // every NSNumber is a valid double, so we're good!)
+    if formatter.number(from: self) != nil {
+        // Split our string at the decimal separator
+        let split = self.components(separatedBy: decimalSeparator)
+        // Depending on whether there was a decimalSeparator we may have one
+        // or two parts now. If it is two then the second part is the one after
+        // the separator, aka the digits we care about.
+        // If there was no separator then the user hasn't entered a decimal
+        // number yet and we treat the string as empty, succeeding the check
+        let digits = split.count == 2 ? split.last ?? "" : ""
+        
+        // Finally check if we're <= the allowed digits
+        return digits.count <= maxDecimalPlaces    // TODO: Swift 4.0 replace with digits.count, YAY!
+    }
+    return false // couldn't turn string into a valid number
   }
   
   func isPhoneNumber() -> Bool {

--- a/RSFormView/Classes/Models/FormField.swift
+++ b/RSFormView/Classes/Models/FormField.swift
@@ -113,8 +113,10 @@ open class FormField {
       validationType = .fiveDigitZipCode
     case .password:
       validationType = .nonEmpty
-    case .numeric:
-      validationType = .numeric
+    case .integer:
+      validationType = .integer
+    case .double:
+        validationType = .double
     case .usState:
       validationType = .usState
     case .picker:

--- a/RSFormView/Classes/ViewModels/FormViewModel.swift
+++ b/RSFormView/Classes/ViewModels/FormViewModel.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public enum FieldType {
   case email
-  case numeric
+  case integer
+  case double
   case date
   case usState
   case usPhone
@@ -29,7 +30,8 @@ public enum ValidationType {
   case expiration
   case fiveDigitZipCode
   case usPhone
-  case numeric
+  case integer
+  case double
   case custom(evaluator: (String) -> (Bool))
 }
 

--- a/RSFormView/Classes/Views/TextField/TextFieldViewPrivateExtension.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldViewPrivateExtension.swift
@@ -77,8 +77,10 @@ internal extension TextFieldView {
   func setKeyboardType() {
     guard let fieldData = fieldData else { return }
     switch fieldData.fieldType {
-    case .numeric, .usPhone, .fiveDigitZipCode, .expiration:
+    case .integer, .usPhone, .fiveDigitZipCode, .expiration:
       textField.keyboardType = .numberPad
+    case .double:
+        textField.keyboardType = .decimalPad
     case .email:
       textField.keyboardType = .emailAddress
     default:


### PR DESCRIPTION
This PR adds a new field type `double` with `UIKeyboardType.decimalPad`, and new validation type `double` that checks for valid Doubles up to 2 decimal places.

`numeric` has been renamed to `integer` to avoid confusion.

The README has been updated accordingly.

This is my first PR - apologies if I've done anything wrong!