### PR TITLE
Populate an empty picker UITextField with the first fieldData.options when selected

### DIFF
--- a/RSFormView/Classes/Views/TextField/TextFieldView.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldView.swift
@@ -274,6 +274,16 @@ extension TextFieldView: UITextFieldDelegate {
     return true
   }
   
+  func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+    guard let data = fieldData,
+        data.fieldType == .picker else { return true }
+    guard let fieldOptions = fieldData?.options else { return true }
+    if textField.text?.count == 0 {
+        textField.text = fieldOptions[0]
+    }
+    return true
+  }
+  
   func textFieldDidBeginEditing(_ textField: UITextField) {
     titleLabel.textColor = formConfigurator.editingTitleColor
     textField.placeholder = ""

--- a/RSFormView/Classes/Views/TextField/TextFieldView.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldView.swift
@@ -276,10 +276,10 @@ extension TextFieldView: UITextFieldDelegate {
   
   func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
     guard let data = fieldData,
-        data.fieldType == .picker else { return true }
-    guard let fieldOptions = fieldData?.options else { return true }
+      let fieldOptions = fieldData?.options,
+      data.fieldType == .picker else { return true }
     if textField.text?.isEmpty ?? true {
-        textField.text = fieldOptions[0]
+      textField.text = fieldOptions[0]
     }
     return true
   }

--- a/RSFormView/Classes/Views/TextField/TextFieldView.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldView.swift
@@ -275,11 +275,11 @@ extension TextFieldView: UITextFieldDelegate {
   }
   
   func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-    guard let data = fieldData,
-      let fieldOptions = fieldData?.options,
-      data.fieldType == .picker else { return true }
-    if textField.text?.isEmpty ?? true {
-      textField.text = fieldOptions[0]
+    if let data = fieldData,
+        let options = data.options,
+        data.fieldType == .picker,
+        textField.text?.isEmpty ?? true {
+        update(withPickerText: options[0])
     }
     return true
   }

--- a/RSFormView/Classes/Views/TextField/TextFieldView.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldView.swift
@@ -278,7 +278,7 @@ extension TextFieldView: UITextFieldDelegate {
     guard let data = fieldData,
         data.fieldType == .picker else { return true }
     guard let fieldOptions = fieldData?.options else { return true }
-    if textField.text?.count == 0 {
+    if textField.text?.isEmpty ?? true {
         textField.text = fieldOptions[0]
     }
     return true


### PR DESCRIPTION
Adds a new default behaviour where the first option from `fieldData.options` is automatically inputted into a `UITextField` when it is selected if:
1. The `UITextField` in question is empty.
2. It is of the type `.picker`.