### PR TITLE
Refactored class structure for FormCells

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		E20AAFD52D5B2E1CA694E3B1B547899F /* AddressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4FD24222324C7E7EF40FFAE7807089 /* AddressManager.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E3A3AF2D937F7B7DA923CEF36CCCDD15 /* RSFormView-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B0CD6FF5E843A618282A2FC81683DCD8 /* RSFormView-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		F886635DB8B24AF65559B6EC26B32C65 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2896A26F3CB30FB3CD89BB041B357AAE /* StringExtension.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FEDB766722BA79DF0029D8C2 /* FormCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDB766622BA79DF0029D8C2 /* FormCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,13 +101,13 @@
 		2896A26F3CB30FB3CD89BB041B357AAE /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		28D6DEAFBD05DE94200D967AA62839A3 /* FormViewPrivateExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormViewPrivateExtension.swift; sourceTree = "<group>"; };
 		2910B0FACFD4FE2B109E760776650DC9 /* IQToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQToolbar.swift; path = IQKeyboardManagerSwift/IQToolbar/IQToolbar.swift; sourceTree = "<group>"; };
-		2C96E922FAF8B4D830253F474ECD535F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		2D929055228486A7E7FBB2C1048122FD /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		2C96E922FAF8B4D830253F474ECD535F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		2D929055228486A7E7FBB2C1048122FD /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		31EDBDF8D65BAF3BA816D27A77DCCAF9 /* TextFieldCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextFieldCell.swift; sourceTree = "<group>"; };
 		39385EA3D9F06CFC5270DB21D07C4BFC /* IQKeyboardManagerConstantsInternal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardManagerConstantsInternal.swift; path = IQKeyboardManagerSwift/Constants/IQKeyboardManagerConstantsInternal.swift; sourceTree = "<group>"; };
 		3998CBD2832F5EFF0872CDE916FCC249 /* IQKeyboardManagerSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IQKeyboardManagerSwift.modulemap; sourceTree = "<group>"; };
 		3F2801A1876AA32949531E26E5C31C53 /* IQUIView+IQKeyboardToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "IQUIView+IQKeyboardToolbar.swift"; path = "IQKeyboardManagerSwift/IQToolbar/IQUIView+IQKeyboardToolbar.swift"; sourceTree = "<group>"; };
-		40775C37404E0F65E63D1BC2E7329263 /* libPods-RSFormViewExampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-RSFormViewExampleApp.a"; path = "libPods-RSFormViewExampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		40775C37404E0F65E63D1BC2E7329263 /* libPods-RSFormViewExampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RSFormViewExampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B4971CB334DEDED4AC31ECE740FF2B4 /* TwoTextFieldsCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = TwoTextFieldsCell.xib; sourceTree = "<group>"; };
 		610789A3814696226317BC841E8B94AA /* TextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextFieldView.swift; sourceTree = "<group>"; };
 		61616DC0A1B429402046E71B919CDDCF /* RSFormView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RSFormView-dummy.m"; sourceTree = "<group>"; };
@@ -121,22 +122,22 @@
 		95F0704E7F1E09778370551A453026DB /* RSFormView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RSFormView-prefix.pch"; sourceTree = "<group>"; };
 		9826FFA73109A0B2C99FCBEF5EA1A2D4 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		9932CD4A6AB7468364076D56A13BBFCD /* FormView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = FormView.xib; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9DAF1144E71332BDA240606619627081 /* FormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormView.swift; sourceTree = "<group>"; };
 		9DE0105E5465C9D3CA2359EA28C4B4A9 /* RSFormView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RSFormView.h; path = RSFormView/Classes/RSFormView.h; sourceTree = "<group>"; };
 		9EBC45F213AB0ECB5911D50DC9C8AC7D /* IQKeyboardManagerSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IQKeyboardManagerSwift-dummy.m"; sourceTree = "<group>"; };
 		A0E5E8D23920C32CAB6A2C0408FC30F8 /* IQKeyboardReturnKeyHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQKeyboardReturnKeyHandler.swift; path = IQKeyboardManagerSwift/IQKeyboardReturnKeyHandler.swift; sourceTree = "<group>"; };
 		A292723098B5E0FECA35FC76EFB498F9 /* IQBarButtonItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQBarButtonItem.swift; path = IQKeyboardManagerSwift/IQToolbar/IQBarButtonItem.swift; sourceTree = "<group>"; };
 		A65CED11CBD35096251FBEB17EB27AF6 /* IQTitleBarButtonItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IQTitleBarButtonItem.swift; path = IQKeyboardManagerSwift/IQToolbar/IQTitleBarButtonItem.swift; sourceTree = "<group>"; };
-		A8E950A16D00F649C54FFB30F81D7842 /* libIQKeyboardManagerSwift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libIQKeyboardManagerSwift.a; path = libIQKeyboardManagerSwift.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		ABD2D192FC8A7E06154AE48D1E236253 /* libRSFormView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libRSFormView.a; path = libRSFormView.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE2DD504FDDF724A41FD4AA6FC9E3A84 /* RSFormView.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = RSFormView.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A8E950A16D00F649C54FFB30F81D7842 /* libIQKeyboardManagerSwift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libIQKeyboardManagerSwift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABD2D192FC8A7E06154AE48D1E236253 /* libRSFormView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRSFormView.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE2DD504FDDF724A41FD4AA6FC9E3A84 /* RSFormView.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = RSFormView.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		AE3AF06B88E0C23774BEF218C5A996BE /* RSFormView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RSFormView.xcconfig; sourceTree = "<group>"; };
 		AF0CF5BB09D450E20041414E0D144146 /* Pods-RSFormViewExampleApp-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-RSFormViewExampleApp-resources.sh"; sourceTree = "<group>"; };
 		B0CD6FF5E843A618282A2FC81683DCD8 /* RSFormView-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RSFormView-umbrella.h"; sourceTree = "<group>"; };
 		BD08AA9BEA60937695A94F97FD883C1A /* ViewExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
 		C10EECFB250C3CB12D8C1F5F58B458B9 /* IQKeyboardManagerSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IQKeyboardManagerSwift-umbrella.h"; sourceTree = "<group>"; };
-		C5B241B4B094A5BBB650AA403F596142 /* RSFormView.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = RSFormView.bundle; path = "RSFormView-RSFormView.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5B241B4B094A5BBB650AA403F596142 /* RSFormView.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RSFormView.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB0FEFA1432490DB07D9231D8BCABCC1 /* FormField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		CCF0CFC4E50D4E0CAE5208F5D134946A /* FormTextCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormTextCell.swift; sourceTree = "<group>"; };
 		CFC5FD3BCD80F6466158F18C812E1893 /* IQKeyboardManagerSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IQKeyboardManagerSwift-prefix.pch"; sourceTree = "<group>"; };
@@ -148,6 +149,7 @@
 		EB0452F2A998F08149F0E1767834C6D4 /* ResourceBundle-RSFormView-RSFormView-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-RSFormView-RSFormView-Info.plist"; sourceTree = "<group>"; };
 		FA38505A8720A890F3C0782CCD81B35E /* RSFormView.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = RSFormView.modulemap; sourceTree = "<group>"; };
 		FB22C05F1352D51F007C1DA8DBD7C254 /* IQKeyboardManagerSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IQKeyboardManagerSwift.xcconfig; sourceTree = "<group>"; };
+		FEDB766622BA79DF0029D8C2 /* FormCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCell.swift; sourceTree = "<group>"; };
 		FEE318700072A1E7F63B02D1B688A93D /* IQKeyboardManager.bundle */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.plug-in"; name = IQKeyboardManager.bundle; path = IQKeyboardManagerSwift/Resources/IQKeyboardManager.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -251,7 +253,6 @@
 				610789A3814696226317BC841E8B94AA /* TextFieldView.swift */,
 				76C8F9D51912A2C0239380D1AE98DAF8 /* TextFieldViewPrivateExtension.swift */,
 			);
-			name = TextField;
 			path = TextField;
 			sourceTree = "<group>";
 		};
@@ -283,8 +284,8 @@
 				CCF0CFC4E50D4E0CAE5208F5D134946A /* FormTextCell.swift */,
 				31EDBDF8D65BAF3BA816D27A77DCCAF9 /* TextFieldCell.swift */,
 				0EA9819C8C9D62F0DD10EE2EB1940099 /* TwoTextFieldsCell.swift */,
+				FEDB766622BA79DF0029D8C2 /* FormCell.swift */,
 			);
-			name = Cell;
 			path = Cell;
 			sourceTree = "<group>";
 		};
@@ -302,7 +303,6 @@
 				9DAF1144E71332BDA240606619627081 /* FormView.swift */,
 				28D6DEAFBD05DE94200D967AA62839A3 /* FormViewPrivateExtension.swift */,
 			);
-			name = Form;
 			path = Form;
 			sourceTree = "<group>";
 		};
@@ -449,7 +449,6 @@
 				7BAE7CC16D3CA53193DEC7C642BE612F /* Resources */,
 				AAD1CDBAF1D477515E2CCCBB361638F3 /* Support Files */,
 			);
-			name = IQKeyboardManagerSwift;
 			path = IQKeyboardManagerSwift;
 			sourceTree = "<group>";
 		};
@@ -695,6 +694,7 @@
 				C5EDA495BB6BB0F97DE255A291D14ABC /* FormConfigurator.swift in Sources */,
 				2E92C2D05B59D0208613A58C6B30CE5C /* FormField.swift in Sources */,
 				2E56C0A58569E737C9A37E5ECE2FAE18 /* FormTextCell.swift in Sources */,
+				FEDB766722BA79DF0029D8C2 /* FormCell.swift in Sources */,
 				A7D1293D708D895B6B7260B6B089B1FB /* FormView.swift in Sources */,
 				993B255E0ECF0E480F154F826A6ACDE6 /* FormViewModel.swift in Sources */,
 				3CB08C6EEE5D7028C4345B0F8C1A0261 /* FormViewPrivateExtension.swift in Sources */,

--- a/RSFormView/Classes/Views/Cell/FormCell.swift
+++ b/RSFormView/Classes/Views/Cell/FormCell.swift
@@ -1,0 +1,34 @@
+//
+//  FormCell.swift
+//  RSFormView
+//
+//  Created by Mauricio Cousillas on 6/19/19.
+//
+
+import UIKit
+
+/**
+  Protocol used to notify changes from the cell to the FormView,
+  use this to update the formViewModel. Otherwise your data will
+  end out of sync.
+*/
+public protocol FormCellDelegate: class {
+  func didUpdate(data: FormField)
+}
+
+/**
+  Base class for every cell that will be displayed on the FormView.
+  To create new types of cells, you need to inherit from this class,
+  and override the update method
+ */
+public class FormTableViewCell: UITableViewCell {
+  open weak var delegate: FormCellDelegate?
+
+  /// Called every time the cell is rendered
+  open func update(with formItem: FormItem, and formConfigurator: FormConfigurator) {
+    assert(true, "Override this method to set up your cell")
+  }
+
+  /// Called when the cell needs to update to it's error state.
+  open func updateErrorState() { }
+}

--- a/RSFormView/Classes/Views/Cell/FormTextCell.swift
+++ b/RSFormView/Classes/Views/Cell/FormTextCell.swift
@@ -9,14 +9,14 @@
 import Foundation
 import UIKit
 
-class FormTextCell: UITableViewCell {
+class FormTextCell: FormTableViewCell {
   
   static let reuseIdentifier = "FormTextCellIdentifier"
   @IBOutlet weak var formTextLabel: UILabel!
   @IBOutlet weak var headerLabelTopMarginConstraint: NSLayoutConstraint!
   @IBOutlet weak var headerLabelBottomMarginConstraint: NSLayoutConstraint!
   
-  func update(withFormItem formItem: FormItem, formConfigurator: FormConfigurator) {
+  override func update(with formItem: FormItem, and formConfigurator: FormConfigurator) {
     headerLabelTopMarginConstraint.constant = formItem.contraintsConfigurator.headerLabelTopMargin
     headerLabelBottomMarginConstraint.constant = formItem.contraintsConfigurator.headerLabelBottomMargin
     formTextLabel.attributedText = formItem.attributedText

--- a/RSFormView/Classes/Views/Cell/TextFieldCell.swift
+++ b/RSFormView/Classes/Views/Cell/TextFieldCell.swift
@@ -9,32 +9,23 @@
 import Foundation
 import UIKit
 
-protocol FormCellDelegate: class {
-  func didUpdate(data: FormField)
-}
-
-protocol FormViewCell: class {
-  func updateErrorState()
-}
-
-class TextFieldCell: UITableViewCell, FormViewCell {
+class TextFieldCell: FormTableViewCell {
   
   static let reuseIdentifier = "TextFieldCellIdentifier"
   
   @IBOutlet weak var textFieldView: TextFieldView!
-  
-  weak var delegate: FormCellDelegate?
-  
+
   override func awakeFromNib() {
     textFieldView.delegate = self
   }
   
-  func update(withData data: FormField, formConfigurator: FormConfigurator) {
+  override func update(with formItem: FormItem, and formConfigurator: FormConfigurator) {
     isAccessibilityElement = false
-    textFieldView.update(withData: data, formConfigurator: formConfigurator)
+    guard let fieldData = formItem.formFields.first else { return }
+    textFieldView.update(withData: fieldData, formConfigurator: formConfigurator)
   }
   
-  func updateErrorState() {
+  override func updateErrorState() {
     textFieldView.updateErrorState()
   }
   

--- a/RSFormView/Classes/Views/Cell/TwoTextFieldsCell.swift
+++ b/RSFormView/Classes/Views/Cell/TwoTextFieldsCell.swift
@@ -9,21 +9,19 @@
 import Foundation
 import UIKit
 
-class TwoTextFieldsCell: UITableViewCell, FormViewCell {
+class TwoTextFieldsCell: FormTableViewCell {
   
   static let reuseIdentifier = "TwoTextFieldsCellIdentifier"
   
   @IBOutlet weak var firstTextField: TextFieldView!
   @IBOutlet weak var secondTextField: TextFieldView!
   
-  weak var delegate: FormCellDelegate?
-  
   override func awakeFromNib() {
     firstTextField.delegate = self
     secondTextField.delegate = self
   }
   
-  func update(withFormItem formItem: FormItem, formConfigurator: FormConfigurator) {
+  override func update(with formItem: FormItem, and formConfigurator: FormConfigurator) {
     guard formItem.formFields.count == 2 else { return }
     
     let firstFieldData = formItem.formFields[0]
@@ -43,7 +41,7 @@ class TwoTextFieldsCell: UITableViewCell, FormViewCell {
     textFieldView.update(withData: data, formConfigurator: formConfigurator)
   }
   
-  func updateErrorState() {
+  override func updateErrorState() {
     firstTextField.updateErrorState()
     secondTextField.updateErrorState()
   }

--- a/RSFormView/Classes/Views/Form/FormView.swift
+++ b/RSFormView/Classes/Views/Form/FormView.swift
@@ -52,7 +52,7 @@ public protocol FormViewDelegate: class {
   /// Updates the error state for every visible FormItems
   public func reloadVisibleCells() {
     for cell in formTableView.visibleCells {
-      if let cell = cell as? FormViewCell {
+      if let cell = cell as? FormTableViewCell {
         cell.updateErrorState()
       }
     }
@@ -72,7 +72,7 @@ public protocol FormViewDelegate: class {
 }
 
 extension FormView: FormCellDelegate {
-  func didUpdate(data: FormField) {
+  public func didUpdate(data: FormField) {
     checkMatches(updatedField: data)
     reloadVisibleCells()
     delegate?.didUpdateFields(in: self,
@@ -88,22 +88,23 @@ extension FormView: UITableViewDelegate, UITableViewDataSource {
   
   public func tableView(_ tableView: UITableView,
                  cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    
-    let rowFields = viewModel?.items[indexPath.row].formFields
-    
-    if let formItem = viewModel?.items[indexPath.row],
-      let _ = formItem.attributedText,
-        rowFields?.isEmpty ?? true,
-        let cell = tableView
-          .dequeueReusableCell(withIdentifier: FormTextCell.reuseIdentifier,
-                               for: indexPath) as? FormTextCell {
-        cell.update(withFormItem: formItem, formConfigurator: formConfigurator)
-        return cell
-      }
-    
-    return textFieldCell(forRowAt: indexPath,
-                         in: tableView,
-                         with: rowFields)
+    let formItem = viewModel?.items[indexPath.row]
+
+    let reuseId = reuseIdentifier(forRowAt: indexPath, with: formItem)
+
+    let cell = tableView.dequeueReusableCell(withIdentifier: reuseId,
+                                             for: indexPath)
+
+    guard
+      let formCell = cell as? FormTableViewCell,
+      let item = formItem
+    else {
+      return cell
+    }
+
+    formCell.delegate = self
+    formCell.update(with: item, and: formConfigurator)
+    return formCell
   }
     
 }

--- a/RSFormView/Classes/Views/Form/FormViewPrivateExtension.swift
+++ b/RSFormView/Classes/Views/Form/FormViewPrivateExtension.swift
@@ -46,29 +46,20 @@ internal extension FormView {
       validationMatch.isValid = validationMatch.value == updatedField.value
     }
   }
-  
-  func textFieldCell(forRowAt indexPath: IndexPath,
-                                 in tableView: UITableView,
-                                 with rowFields: [FormField]?) -> UITableViewCell {
-    if rowFields?.count == 1,
-      let fieldData = rowFields?.first,
-      let cell = tableView
-        .dequeueReusableCell(withIdentifier: TextFieldCell.reuseIdentifier,
-                             for: indexPath) as? TextFieldCell {
-      cell.update(withData: fieldData, formConfigurator: formConfigurator)
-      cell.delegate = self
-      return cell
+
+  func reuseIdentifier(forRowAt indexPath: IndexPath, with formItem: FormItem?) -> String {
+    guard let formItem = formItem else {
+      return FormTextCell.reuseIdentifier
+    }
+
+    let rowFields = formItem.formFields
+
+    if rowFields.count == 1 && formItem.attributedText == nil {
+      return TextFieldCell.reuseIdentifier
+    } else if rowFields.count == 2 {
+      return TwoTextFieldsCell.reuseIdentifier
     }
     
-    let cell = tableView.dequeueReusableCell(withIdentifier: TwoTextFieldsCell.reuseIdentifier,
-                                             for: indexPath)
-    if let formItem = viewModel?.items[indexPath.row],
-      formItem.formFields.count == 2,
-      let cell = cell as? TwoTextFieldsCell {
-      cell.delegate = self
-      cell.update(withFormItem: formItem, formConfigurator: formConfigurator)
-    }
-    
-    return cell
+    return FormTextCell.reuseIdentifier
   }
 }


### PR DESCRIPTION
Did some refactoring to make cell creation and reuse simpler:
- `FormTableViewCell` is now the base class that every cell should inherit from.
- Left `update` and `updateErrorState` as points of customization for each cell to override.