### PR TITLE
Fixed last name validation in example

### DIFF
--- a/Example/RSFormViewExampleApp/SignupExampleViewModel.swift
+++ b/Example/RSFormViewExampleApp/SignupExampleViewModel.swift
@@ -97,7 +97,7 @@ class SignupExampleViewModel: FormViewModel {
     lastNameField.validationType = .custom(evaluator: { [weak self] value in
       let nameField = self?.fields().first { $0.name == FieldName.firstName.rawValue }
       let nameValue = nameField?.value ?? ""
-      return value.count > 5 && value == nameValue
+      return value.count > 1 && value != nameValue
     })
     return lastNameField
   }

--- a/Example/RSFormViewExampleAppUITests/RSFormViewExampleAppUITests.swift
+++ b/Example/RSFormViewExampleAppUITests/RSFormViewExampleAppUITests.swift
@@ -58,7 +58,7 @@ class RSFormViewExampleAppUITests: XCTestCase {
     toolbarNextButton.tap()
     
     let lastNameTextField = app.textField(with: "LAST NAME")
-    lastNameTextField.typeText("German")
+    lastNameTextField.typeText("Stabile")
     
     app.textField(with: "DOB").tap()
     


### PR DESCRIPTION
### Goals :soccer:
- Fix validation logic in example project.

### Implementation Details :construction:
- Updated the last name validation logic to:
  1. Ensure the last name is not equal to the first name 
  2. Text is at least 2 characters.  

Please let me know if my assumptions are wrong.  Happy to make changes.