### PR TITLE
Feature/limit expiration type characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ To contribute to this library: fork this repository and create a Pull Request fr
 
 You can also open issues in this repository and our team will tackle them as soon as possible.
 
+## License
+
+RSFormView is available under the MIT license. See the LICENSE file for more info.
+
 ## Credits
 
 **RSFormView** is authored and mantained by [Rootstrap](http://www.rootstrap.com) and [German Stabile](https://github.com/germanStabile) with the help of our [contributors](https://github.com/rootstrap/RSFormView/contributors).
+
+[<img src="https://s3-us-west-1.amazonaws.com/rootstrap.com/img/rs.png" width="100"/>](http://www.rootstrap.com)

--- a/RSFormView/Classes/Views/TextField/TextFieldViewPrivateExtension.swift
+++ b/RSFormView/Classes/Views/TextField/TextFieldViewPrivateExtension.swift
@@ -167,6 +167,11 @@ internal extension TextFieldView {
       return updatedText
     }
     
+    if updatedText.count > 7 {
+      //if we have more characters than the format mm/yyyy, don't update the text
+      return previousText
+    }
+    
     var resultingText = ""
     switch previousText.count {
     case 0:


### PR DESCRIPTION
#### Description:

* The expiration type is intended to have the format 'mm/yy' or 'mm/yyyy'. 
* This PR limits the characters

---


#### Notes:

* No notes

---

#### Risk:

* I feel this type is too specific for being part of the main library. It could be an add-on , part of a different pod. 

---

#### Preview:

![demo](https://user-images.githubusercontent.com/677752/66520151-02e92e00-eabf-11e9-9aac-b05596ae1317.gif)
